### PR TITLE
chore: use consistent default `port` for `serve`

### DIFF
--- a/src/node/serve/serve.ts
+++ b/src/node/serve/serve.ts
@@ -21,7 +21,9 @@ export interface ServeOptions {
 }
 
 export async function serve(options: ServeOptions = {}) {
-  const port = options.port !== undefined ? options.port : 5000
+  // align with `vite preview`
+  // https://github.com/vitejs/vite/blob/3f9e5d49dfeb25ee22423fb5d180fe63b1c23c41/packages/vite/src/node/preview.ts#L119
+  const port = options.port !== undefined ? options.port : 4173
   const site = await resolveConfig(options.root, 'serve', 'production')
   const base = trimChar(site?.site?.base ?? '', '/')
 


### PR DESCRIPTION
close #715